### PR TITLE
Add some basic features and dataframe size calculators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+extend-ignore = E501, E203, E731
+exclude = build, dist, .git, .tox, tests, venv, .venv, .pyenv, docs, examples, .poetry, .pip-installation
+max-line-length = 119

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,10 @@ default_language_version:
 default_stages: [commit, push]
 
 repos:
+    - repo: https://github.com/ambv/black
+      rev: 22.3.0
+      hooks:
+        - id: black
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.3.0
       hooks:

--- a/pyspark_partitions/helpers.py
+++ b/pyspark_partitions/helpers.py
@@ -1,3 +1,7 @@
+import logging
+from pyspark.sql import DataFrame
+
+
 def count_number_of_partitions(iterator):
     """
     Simply returns de number of nonempty partitions in a DataFrame.
@@ -9,3 +13,35 @@ def count_number_of_partitions(iterator):
         n += 1
         break
     yield n
+
+
+def df_size_in_bytes_exact(df: DataFrame):
+    """
+    Calculates the exact size in memory of a DataFrame by caching it and accessing the optimized plan
+
+    NOTE: BE CAREFUL WITH THIS FUNCTION BECAUSE IT WILL CACHE ALL THE DATAFRAME!!! IF YOUR DATAFRAME IS
+    TOO BIG USE `estimate_df_size_in_bytes`!!
+
+    :param df: A pyspark DataFrame
+    :return: The exact size in bytes
+    """
+    df = df.cache().select(
+        df.columns
+    )  # Just force the Spark planner to add the Cache op to the plan
+    logging.info(f"Number of rows in the input DataFrame: {df.count()}")
+    size_in_bytes = df._jdf.queryExecution().optimizedPlan().stats().sizeInBytes()
+    df.unpersist(blocking=True)
+    return size_in_bytes
+
+
+def df_size_in_bytes_approximate(df: DataFrame, sample_perc: float = 0.05):
+    """
+    This method takes a sample of the input DataFrame (`sample_perc`) and applies `df_size_in_bytes_exact`
+    method to it. After it calculates the exact size of the sample, it extrapolates the total size.
+
+    :param df: A pyspark DataFrame
+    :param sample_perc: The percentage of the DataFrame to sample. By default, a 5 %
+    :return: The estimated size in bytes
+    """
+    sample_size_in_bytes = df_size_in_bytes_exact(df.sample(sample_perc))
+    return sample_size_in_bytes / sample_perc

--- a/pyspark_partitions/helpers.py
+++ b/pyspark_partitions/helpers.py
@@ -1,0 +1,11 @@
+def count_number_of_partitions(iterator):
+    """
+    Simply returns de number of nonempty partitions in a DataFrame.
+    :param iterator: An iterator containing each partition
+    :return:
+    """
+    n = 0
+    for _ in iterator:
+        n += 1
+        break
+    yield n

--- a/pyspark_partitions/repartitioning.py
+++ b/pyspark_partitions/repartitioning.py
@@ -1,0 +1,45 @@
+from typing import Union
+
+from pyspark.sql import DataFrame
+from pyspark.sql._typing import ColumnOrName
+
+from pyspark_partitions.helpers import count_number_of_partitions
+
+
+def repartition(
+    df: DataFrame,
+    numPartitions: Union[int, "ColumnOrName"],
+):
+    """
+    Acts as a safe repartition function. If we are trying to repartition by a number of partitions `numPartitions` less
+    than the number of current partitions, it will automatically make a coalesce operation.
+
+    Note: This method will only be useful if we DO NOT WANT TO REPARTITION BY ANY OTHER COLUMN. If we want to
+    reduce the number of partitions but still maintain partitions by some columns, we will need to use the
+    usual `df.repartition(...)`
+
+    :param df: A Pyspark DataFrame
+    :param numPartitions: Number of partitions
+    :return: A partitioned Dataframe
+    """
+    if df.rdd.getNumPartitions() < numPartitions:
+        df = df.repartition(numPartitions)
+    elif df.rdd.getNumPartitions() > numPartitions:
+        df = df.coalesce(numPartitions)
+    return df
+
+
+def remove_empty_partitions(df: DataFrame):
+    """
+    This method will remove empty partitions from a DataFrame. It is useful after a filter, for
+    example, when a great number of partitions may contain zero registers.
+
+    Note: This functionality may be useless if you are using Adaptive Query Execution from Spark 3.0
+
+    :param df: A pyspark DataFrame
+    :return: A DataFrame with all empty partitions removed
+    """
+    non_empty_partitions = sum(
+        df.rdd.mapPartitions(count_number_of_partitions).collect()
+    )
+    return df.coalesce(non_empty_partitions)


### PR DESCRIPTION
Introduces the following methods:

1. df_size_in_bytes_exact -> Calculates the exact size of a DataFrame in Bytes
2. df_size_in_bytes_approximate -> Calculates an approximation of a DataFrame size in Bytes using sampling
3. remove_empty_partitions -> Method to remove unnecessary empty partitions (common after filters, aggregations, etc.)